### PR TITLE
Change from dotenv to config.json

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,0 @@
-# Create at https://makersuite.google.com/
-GOOGLE_AI_KEY = "GOOGLE_AI_KEY"
-
-# Create at https://discord.com/developers/applications
-DISCORD_BOT_TOKEN = "DISCORD_BOT_KEY"
-
-# Disable history by setting to 0
-MAX_HISTORY = 15

--- a/example.config.md
+++ b/example.config.md
@@ -1,0 +1,51 @@
+From GeminiDiscordBot.py
+{
+    "GOOGLE_AI_KEY": "",
+    "DISCORD_BOT_TOKEN": "",
+    "MAX_HISTORY": 0,
+    "SUMMERIZE_PROMPT": "Give me 5 bullets about",
+    "text_generation_config": {
+        "temperature": 0.9,
+        "top_p": 1,
+        "top_k": 1,
+        "max_output_tokens": 512
+    },
+    "safety_settings": [
+        {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_ONLY_HIGH"},
+        {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_ONLY_HIGH"},
+        {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "BLOCK_ONLY_HIGH"},
+        {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "BLOCK_ONLY_HIGH"}
+    ],
+    "model_name": "gemini-1.5-flash",
+    "system_instruction":"" 
+}
+
+
+From GeminiSimple.py
+{
+    "GOOGLE_AI_KEY": "",
+    "DISCORD_BOT_TOKEN": "",
+    "MAX_HISTORY": 0,
+    "SUMMERIZE_PROMPT": "Give me 5 bullets about", 
+    "text_generation_config": {
+        "temperature": 0.9,
+        "top_p": 1,
+        "top_k": 1,
+        "max_output_tokens": 512
+    },
+    "image_generation_config" : {
+        "temperature": 0.4,
+        "top_p": 1,
+        "top_k": 32,
+        "max_output_tokens": 512
+    },
+    "safety_settings": [
+        {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_ONLY_HIGH"},
+        {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_ONLY_HIGH"},
+        {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "BLOCK_ONLY_HIGH"},
+        {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "BLOCK_ONLY_HIGH"}
+    ],
+    "model_name": "gemini-1.5-flash",
+    "system_instruction":"You are a helpful bot!",
+    "image_instruction": "You are a helpful bot!"
+}


### PR DESCRIPTION
Replaced dotenv to json.
Added config.json to contain all of the settings, including Gemini's API settings.
Added autogeneration of config.json if it is not present.


Hello! I suggest adding a config.json to contain all the settings, so every settings will be accessible from the config file instead of straight inside the python script and the env file for api keys

This might be useful if the user wants customizable instance of the bot when running under the same environment. (Different tokens/api key)