### PR TITLE
added audioop-lts in requirements for compatibility with python 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The original bot that just does text and images is under `GeminiSimple.py`, If y
 - PyMuPDF (PDF reading)
 - requests
 - beautifulsoup4 (scraping)
+- audioop-lts (only when you are using python 3.13 or newer)
 
   Recently updated to use Google Flash 1.5 you may need to update your python package
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ youtube-transcript-api
 PyMuPDF
 requests
 beautifulsoup4
+audioop-lts


### PR DESCRIPTION
discord.py uses the package "audioop" which was deprecated and afterwards deleted in python 3.13 which causes discord.py to stop functioning. this pull request adds the package "audioop-lts" to continue using discord.py